### PR TITLE
Add quick navigation to Terms of Service page

### DIFF
--- a/src/components/terms/TermsOfService.tsx
+++ b/src/components/terms/TermsOfService.tsx
@@ -53,7 +53,7 @@ const TermsOfService = () => {
                 onClick={() => {
                   const element = document.getElementById(`section-${item.id}`);
                   if (element) {
-                    const navbarHeight = 80; // Adjust based on your navbar height
+                    const navbarHeight = 80;
                     const elementPosition = element.getBoundingClientRect().top + window.pageYOffset;
                     const offsetPosition = elementPosition - navbarHeight;
                     


### PR DESCRIPTION
## UI/UX: Add Quick Navigation to Terms of Service Page

### Summary
This PR adds a quick navigation panel to the Terms of Service page, making it easier for users to jump between sections without excessive scrolling.

### Changes
- Added a responsive quick navigation panel with icons
- Linked navigation buttons to all 11 sections using section IDs
- Enabled smooth scrolling to each section
- Preserved all existing content and styling

### Result
- Improved readability and navigation
- No changes to the Terms content
- Fully responsive and aligned with existing design

### Screenshot
<img width="979" height="387" alt="image" src="https://github.com/user-attachments/assets/1414738a-7a91-4f58-a1c2-796bc27e9b33" />


Closes #42 
