### PR TITLE
fix: increase auto-scroll interval from 4s to 7s for better UX

### DIFF
--- a/src/components/home/FeaturesSection.tsx
+++ b/src/components/home/FeaturesSection.tsx
@@ -106,7 +106,7 @@ const FeaturesSection = () => {
   useEffect(() => {
     intervalRef.current = setInterval(() => {
       setCurrentIndex((prev) => (prev + 1) % features.length);
-    }, 4000);
+    }, 7000);
 
     return () => {
       if (intervalRef.current) {


### PR DESCRIPTION
## Description
Fixes #44 

The auto-scroll timing on the home page features carousel was too fast at 4 seconds, making it difficult for users to read and absorb the feature descriptions before the next slide appeared.

## Changes
- Updated `setInterval` duration from **4000ms to 7000ms** in `FeaturesSection.tsx` (line 107)
- Provides users with adequate time (7 seconds) to read feature details before auto-advancing

## Testing
- Tested the carousel auto-scroll behavior
- Verified that 7 seconds provides a comfortable reading pace
- Confirmed manual navigation (prev/next buttons and dots) still works correctly

## Impact
- **Improved UX**: Users can now comfortably read feature descriptions
- **Better engagement**: More time to absorb content leads to better understanding of features
- **No breaking changes**: Only timing adjustment, all functionality remains the same

## Screenshots/Demo
The carousel will now pause for 7 seconds on each slide instead of 4 seconds, giving users more time to read the detailed descriptions and benefits of each feature.

---
**Type**: Bug Fix  
**Priority**: Medium  
**Labels**: bug, SWoC26, Easy